### PR TITLE
enable listening on IPv6 interface, too

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -2,6 +2,9 @@
     "listeners": {
         "*:8080": {
             "pass": "routes"
+        },
+        "[::]:8080": {
+            "pass": "routes"
         }
     },
     "routes": [


### PR DESCRIPTION
- replicates upstream settings https://github.com/PrivateBin/docker-nginx-fpm-alpine/blob/d7f8653f20b5f0e8be74061e201e243b457a243a/etc/nginx/http.d/site.conf#L3
- fixes #3